### PR TITLE
Add uWrite implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,11 @@ keywords = ["string", "vec", "no_std", "no-std"]
 
 [dependencies]
 tinyvec = "1.6.0"
+ufmt-write = { version = "0.1.0", optional = true }
+
+[dev-dependencies]
+ufmt = { version = "0.2.0" }
+
+[features]
+default = []
+ufmt-impl = ["dep:ufmt-write"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 
 //! This module implements support for a String-like structure that is backed by a slice.
 
+#[cfg(feature = "ufmt-impl")]
+mod ufmt;
+
 use core::{fmt, hash, ops, str};
 pub use tinyvec;
 use tinyvec::SliceVec; // re-export

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -1,0 +1,48 @@
+use crate::SliceString;
+use ufmt_write::uWrite;
+
+impl uWrite for SliceString<'_> {
+    type Error = ();
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        if self.capacity() < self.len() + s.len() {
+            return Err(());
+        }
+
+        self.push_str(s);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ufmt::{derive::uDebug, uwrite};
+
+    use crate::SliceString;
+
+    #[derive(uDebug)]
+    struct Pair {
+        x: u32,
+        y: u32,
+    }
+
+    #[test]
+    fn test_string() {
+        let a = 123;
+        let b = Pair { x: 0, y: 1234 };
+
+        let mut buf = [0u8; 32];
+        let mut s = SliceString::new(&mut buf[..]);
+        uwrite!(s, "{} -> {:?}", a, b).unwrap();
+
+        assert_eq!(s, "123 -> Pair { x: 0, y: 1234 }");
+    }
+
+    #[test]
+    fn test_string_err() {
+        let p = Pair { x: 0, y: 1234 };
+        let mut buf = [0u8; 4];
+        let mut s = SliceString::new(&mut buf[..]);
+        assert!(uwrite!(s, "{:?}", p).is_err());
+    }
+}


### PR DESCRIPTION
`ufmt` and it's `uWrite` trait is supposed to be a smaller alternative to `core::fmt`. I use it in my project when I need to format strings, and now that I have a use case for slice-string I think it would be a nice addition (both slice-string to my project and ufmt support to it :) )